### PR TITLE
Fix crash when a tube emits a digilines signal (carry/borrow/get)

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -67,7 +67,7 @@ local on_digiline_receive_deca = function(pos, node, channel, msg)
 		num = (tonumber(tubenum) or 0) + 1
 		if num > 9 then
 			num = 0
-			digilines:receptor_send(pos, digilines.rules.default, channel, "carry")
+			digilines.receptor_send(pos, digilines.rules.default, channel, "carry")
 		end
 		minetest.swap_node(pos, { name = "nixie_tubes:decatron_"..num, param2 = node.param2})
 
@@ -75,12 +75,12 @@ local on_digiline_receive_deca = function(pos, node, channel, msg)
 		num = (tonumber(tubenum) or 0) - 1
 		if num < 0 then
 			num = 9
-			digilines:receptor_send(pos, digilines.rules.default, channel, "borrow")
+			digilines.receptor_send(pos, digilines.rules.default, channel, "borrow")
 		end
 		minetest.swap_node(pos, { name = "nixie_tubes:decatron_"..num, param2 = node.param2})
 
 	elseif msg == "get" then
-		digilines:receptor_send(pos, digilines.rules.default, channel, tubenum)
+		digilines.receptor_send(pos, digilines.rules.default, channel, tubenum)
 
 	end
 end
@@ -418,10 +418,10 @@ local on_digiline_receive_alnum = function(pos, node, channel, msg)
 			if (asc > 30 and asc < 128) or asc == 144 then
 				minetest.swap_node(pos, { name = "nixie_tubes:alnum_"..asc, param2 = node.param2})
 			elseif msg == "get" then -- get value as ASCII numerical value
-				digilines:receptor_send(pos, digilines.rules.default, channel,
+				digilines.receptor_send(pos, digilines.rules.default, channel,
 					tonumber(string.match(minetest.get_node(pos).name,"nixie_tubes:alnum_(.+)")))
 			elseif msg == "getstr" then -- get actual char
-				digilines:receptor_send(pos, digilines.rules.default, channel, string.char(
+				digilines.receptor_send(pos, digilines.rules.default, channel, string.char(
 					tonumber(string.match(minetest.get_node(pos).name,"nixie_tubes:alnum_(.+)"))))
 			end
 		end


### PR DESCRIPTION
The changes to the carry/borrow/get commands in f1486be (#2) don't appear to have ever worked, instead it just crashes because the function signature is wrong.

The crash in question looks like this:
```
2024-10-01 21:02:41: ERROR[Main]: ServerError: AsyncErr: Lua: Runtime error from mod '*builtin*' in callback item_OnPlace(): /home/medic/mt59/bin/../builtin/game/misc_s.lua:13: attempt to perform arithmetic on field 'z' (a nil value)
2024-10-01 21:02:41: ERROR[Main]: stack traceback:
2024-10-01 21:02:41: ERROR[Main]: 	/home/medic/mt59/bin/../builtin/game/misc_s.lua:13: in function 'hash_node_position'
2024-10-01 21:02:41: ERROR[Main]: 	/home/medic/worlds/creative/worldmods/digilines/init.lua:57: in function 'receptor_send'
2024-10-01 21:02:41: ERROR[Main]: 	...bin/../games/dreambuilder_game/mods/nixie_tubes/init.lua:70: in function 'action'
2024-10-01 21:02:41: ERROR[Main]: 	...e/medic/worlds/creative/worldmods/digilines/internal.lua:106: in function 'transmit'
(lines below this vary depending on where the initial message came from)
```

Specifically, the receptor_send() function can be called like this:
```
digiline:receptor_send(pos,rules,channel,message) (deprecated)
```
or like this:
```
digilines.receptor_send(pos,rules,channel,message)
```
But in f1486be it was being called like this:
```
digilines:receptor_send(pos,rules,channel,message)
```
which doesn't match either of these and ends up putting 'self' where 'pos' should be, which crashes.

Note that this PR does fix this in the "get" and "getstr" commands for the alphanumeric tube as well, but those were not crashing as they don't actually work and I'm not sure they ever have.